### PR TITLE
AWS XEN upgrade update

### DIFF
--- a/reference-new.adoc
+++ b/reference-new.adoc
@@ -17,14 +17,6 @@ Cloud Volumes ONTAP 9.11.0 includes a new enhancement.
 
 Additional features and enhancements are also introduced in the latest versions of BlueXP. See the https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/whats-new.html[BlueXP Release Notes^] for details.
 
-== c4, m4, and r4 instances no longer supported (28 October 2022)
-
-In AWS, the c4, m4, and r4 EC2 instance types are no longer supported with Cloud Volumes ONTAP. If you have an existing system that's running on a c4, m4, or r4 instance type, you must change to an instance type in the c5, m5, or r5 instance family.
-
-link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-change-ec2-instance.html[Learn how to change the EC2 instance type for Cloud Volumes ONTAP^].
-
-Refer to link:https://mysupport.netapp.com/info/communications/ECMLP2880231.html[NetApp Support^] to learn more about the end of availability and support for these instance types. 
-
 == Support for Elastic Volumes (7 June 2022)
 
 Support for the Amazon EBS Elastic Volumes feature with a Cloud Volumes ONTAP aggregate provides better performance and additional capacity, while enabling BlueXP to automatically increase the underlying disk capacity as needed.
@@ -74,3 +66,12 @@ TIP: Automatic upgrades of the Connector are enabled by default so you should be
 * The upgrade of a single node system takes the system offline for up to 25 minutes, during which I/O is interrupted.
 
 * Upgrading an HA pair is nondisruptive and I/O is uninterrupted. During this nondisruptive upgrade process, each node is upgraded in tandem to continue serving I/O to clients.
+
+=== Upgrades in AWS with c4, m4, and r4 EC2 instance types
+
+In AWS, the c4, m4, and r4 EC2 instance types are no longer supported with new Cloud Volumes ONTAP deployments. If you have an existing system that's running on a c4, m4, or r4 instance type, you must change to an instance type in the c5, m5, or r5 instance family. If you can't change the instance type, you need to enable enhanced networking before upgrading. 
+
+link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-updating-ontap-cloud.html#upgrades-in-aws-with-c4-m4-and-r4-ec2-instance-types[Learn how to upgrade in AWS with c4, m4, and r4 EC2 instance types^].
+link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-change-ec2-instance.html[Learn how to change the EC2 instance type for Cloud Volumes ONTAP^].
+
+Refer to link:https://mysupport.netapp.com/info/communications/ECMLP2880231.html[NetApp Support^] to learn more about the end of availability and support for these instance types. 


### PR DESCRIPTION
Includes the following changes:

- Moves information about upgrades with AWS c4, m4, and r4 instances to Upgrade notes on the What's new page
- Provides a reference to the Upgrade Cloud Volumes ONTAP page with details about upgrades with AWS c4, m4, and r4 instances

https://github.com/NetAppDocs/cloud-volumes-ontap-relnotes/issues/64